### PR TITLE
Added BottomNav for more consistent experience

### DIFF
--- a/src/components/App/Navigation/BottomNav.js
+++ b/src/components/App/Navigation/BottomNav.js
@@ -18,7 +18,7 @@ function getCurrentpage (route) {
     case '/profile':
       return 2;
     default:
-      return 0;
+      return 3;
   }
 }
 

--- a/src/components/App/Router/index.js
+++ b/src/components/App/Router/index.js
@@ -29,6 +29,14 @@ const displayNav = (route) => {
       return true;
     case "/profile":
       return true;
+    case "/listings":
+      return true;
+    case "/listing/display":
+      return true;
+    case "/newlisting":
+      return true;
+    case "/updatelisting":
+      return true;
     default:
       return false;
   }


### PR DESCRIPTION
Added the BottomNav to all listing pages, changed the BottomNav display to not highlight an icon when one of the three they represent isn't the current page.