### PR TITLE
New utilities feature to replace the old string based one

### DIFF
--- a/src/components/Listing/CreateListing.js
+++ b/src/components/Listing/CreateListing.js
@@ -103,6 +103,7 @@ function CreateListing(props) {
     }
   }
 
+  //Methods for changing state of the utilities, which triggers a change in the chips too
   const changePower = () => {
       setPower(!power);
   }

--- a/src/components/Listing/CreateListing.js
+++ b/src/components/Listing/CreateListing.js
@@ -2,7 +2,7 @@ import React, { useState } from 'react';
 import DatePicker from 'react-date-picker';
 import "react-calendar/dist/Calendar.css";
 import "react-date-picker/dist/DatePicker.css";
-import { Grid, InputLabel, MenuItem } from '@material-ui/core';
+import { Chip, Typography, Grid, InputLabel, MenuItem } from '@material-ui/core';
 import FormControl from '@material-ui/core/FormControl';
 import Button from '@material-ui/core/Button';
 import ButtonGroup from '@material-ui/core/ButtonGroup';
@@ -14,11 +14,11 @@ import { useAuth } from '../App/Authentication';
 import CssBaseline from '@material-ui/core/CssBaseline';
 import Link from '@material-ui/core/Link';
 import Box from '@material-ui/core/Box';
-import Typography from '@material-ui/core/Typography';
 import { makeStyles } from '@material-ui/core/styles';
 import Container from '@material-ui/core/Container';
 import { Config } from '../../config';
 import Navigation from "../App/Navigation";
+import { Stack } from '@mui/material';
 
 function Copyright() {
   return (
@@ -67,7 +67,10 @@ function CreateListing(props) {
   const [roomAvailable, setRoomAvailable] = useState(currentDate);
   const [rent, setRent] = useState(0);
   const [rentUnits, setRentUnits] = useState("");
-  const [utilities, setUtilities] = useState("");
+  const [utilities, setUtilities] = useState({});
+  const [power, setPower] = useState(false);
+  const [water, setWater] = useState(false);
+  const [internet, setInternet] = useState(false);
 
   //Method to check if an error is detected on form submit - rent can't be $0
   const findError = () => {
@@ -100,6 +103,21 @@ function CreateListing(props) {
       props.history.push('/listings');
     }
   }
+
+  const changePower = () => {
+      setPower(!power);
+      console.log(power);
+  }
+
+  const changeWater = () => {
+    setPower(!water);
+    console.log(water);
+}
+
+const changeInternet = () => {
+    setPower(!internet);
+    console.log(internet);
+}
 
   //Axios method to post the new listing to the DB
   const createNewListing = async () => {
@@ -157,21 +175,6 @@ function CreateListing(props) {
             </div>
             <br /><br /><br /><br />
             <div>
-              <FormControl>
-                <TextField className="input"
-                  label="Utilities"
-                  multiline
-                  maxRows={2}
-                  minRows={2}
-                  required
-                  variant="outlined"
-                  value={utilities}
-                  onChange={(e) => { setUtilities(e.target.value) }}
-                />
-              </FormControl>
-            </div>
-            <br /><br /><br />
-            <div>
               <InputLabel
                 error={isInvalid.rent}
               > Rent Amount (in $NZ)</InputLabel>
@@ -207,6 +210,16 @@ function CreateListing(props) {
               </FormControl>
             </div>
             <br /><br />
+            <InputLabel>Utilities Included</InputLabel>
+            <Grid item xs = {12} >
+                    <br/>
+                    <Stack direction = "row" spacing = {2}>
+                        <Chip id = "power" label = "Power" variant = "outlined" onClick ={changePower}/>
+                        <Chip id = "water" label = "Water" variant = "outlined" onClick ={changeWater}/>
+                        <Chip id = "internet" label = "Internet" variant = "outlined" onClick ={changeInternet}/>
+                    </Stack>
+                </Grid>
+                <br/>
             <div>
               <InputLabel>Available From:</InputLabel>
               <DatePicker

--- a/src/components/Listing/CreateListing.js
+++ b/src/components/Listing/CreateListing.js
@@ -67,7 +67,6 @@ function CreateListing(props) {
   const [roomAvailable, setRoomAvailable] = useState(currentDate);
   const [rent, setRent] = useState(0);
   const [rentUnits, setRentUnits] = useState("");
-  const [utilities, setUtilities] = useState({});
   const [power, setPower] = useState(false);
   const [water, setWater] = useState(false);
   const [internet, setInternet] = useState(false);
@@ -106,22 +105,18 @@ function CreateListing(props) {
 
   const changePower = () => {
       setPower(!power);
-      console.log(power);
   }
 
   const changeWater = () => {
-    setPower(!water);
-    console.log(water);
+    setWater(!water);
 }
 
 const changeInternet = () => {
-    setPower(!internet);
-    console.log(internet);
+    setInternet(!internet);
 }
 
   //Axios method to post the new listing to the DB
   const createNewListing = async () => {
-    // if (props.user.role === 'flat') {
     const URL = 'http://localhost:4000/listings/add/'
 
     const config = {
@@ -134,12 +129,15 @@ const changeInternet = () => {
       roomAvailable: roomAvailable,
       rent: rent,
       rentUnits: rentUnits,
-      utilities: utilities,
+      utilities: {
+          power: power,
+          water: water,
+          internet: internet,
+      },
       active: true
     };
 
     axios.post(URL, bodyParameters, config);
-    // }
   }
 
   return (
@@ -214,9 +212,24 @@ const changeInternet = () => {
             <Grid item xs = {12} >
                     <br/>
                     <Stack direction = "row" spacing = {2}>
-                        <Chip id = "power" label = "Power" variant = "outlined" onClick ={changePower}/>
-                        <Chip id = "water" label = "Water" variant = "outlined" onClick ={changeWater}/>
-                        <Chip id = "internet" label = "Internet" variant = "outlined" onClick ={changeInternet}/>
+                        <Chip 
+                        label = "Power" 
+                        variant = {power == false ? "outlined" : "default"}
+                        onClick ={changePower}
+                        color = {power == false ? "default" : "primary"}
+                        />
+                        <Chip 
+                        label = "Water" 
+                        variant = {water == false ? "outlined" : "default"}
+                        onClick ={changeWater}
+                        color = {water == false ? "default" : "primary"}
+                        />
+                        <Chip 
+                        label = "Internet" 
+                        variant = {internet == false ? "outlined" : "default"} 
+                        onClick ={changeInternet}
+                        color = {internet == false ? "default" : "primary"}
+                        />
                     </Stack>
                 </Grid>
                 <br/>

--- a/src/components/Listing/ListingDisplay.js
+++ b/src/components/Listing/ListingDisplay.js
@@ -1,6 +1,6 @@
 import React, { useEffect, useState } from 'react';
 import { Link as RouterLink, useLocation } from 'react-router-dom';
-import { Grid } from '@material-ui/core';
+import { Chip, Grid } from '@material-ui/core';
 import Button from '@material-ui/core/Button';
 import ButtonGroup from '@material-ui/core/ButtonGroup';
 import * as moment from 'moment';
@@ -17,6 +17,7 @@ import Container from '@material-ui/core/Container';
 import { Config } from '../../config';
 import CardsForListing from "../Match/cardsForListing/index";
 import Navigation from "../App/Navigation";
+import { Stack } from '@mui/material';
 
 function Copyright() {
   return (
@@ -228,7 +229,33 @@ function ListingDisplay(props) {
               { viewMatch &&
               <div>
               <h1>Description: {listing.description}</h1>
-              <h1>Utilities: {listing.utilities}</h1>
+              <h1>Utilities: </h1>
+            <Grid item xs = {12} >
+                    <br/>
+                    <Stack direction = "row" spacing = {2}>
+                        <Chip 
+                        label = "Power" 
+                        variant = {listing.utilities == undefined ? "outlined" : 
+                        (listing.utilities.power == false ? "outlined" : "default")}
+                        color = {listing.utilities == undefined ? "default" : 
+                        (listing.utilities.power == false ? "default" : "primary")}
+                        />
+                        <Chip 
+                        label = "Water" 
+                        variant = {listing.utilities == undefined ? "outlined" : 
+                        (listing.utilities.water == false ? "outlined" : "default")}
+                        color = {listing.utilities == undefined ? "default" : 
+                        (listing.utilities.water == false ? "default" : "primary")}
+                        />
+                        <Chip 
+                        label = "Internet" 
+                        variant = {listing.utilities == undefined ? "outlined" : 
+                        (listing.utilities.internet == false ? "outlined" : "default")} 
+                        color = {listing.utilities == undefined ? "default" : 
+                        (listing.utilities.internet == false ? "default" : "primary")}
+                        />
+                    </Stack>
+                </Grid>
               <h1>Rent: ${listing.rent} {listing.rentUnits}</h1>
               <h1>Available: {date}</h1>
               {renderSwitch()}

--- a/src/components/Listing/UpdateListing.js
+++ b/src/components/Listing/UpdateListing.js
@@ -2,7 +2,7 @@ import React, { useState, useEffect } from 'react';
 import DatePicker from 'react-date-picker';
 import "react-calendar/dist/Calendar.css";
 import "react-date-picker/dist/DatePicker.css";
-import { Grid, InputLabel, MenuItem } from '@material-ui/core';
+import { Chip, Typography, Grid, InputLabel, MenuItem } from '@material-ui/core';
 import FormControl from '@material-ui/core/FormControl';
 import FormControlLabel from '@material-ui/core/FormControlLabel';
 import Switch from '@material-ui/core/Switch';
@@ -16,11 +16,11 @@ import { useAuth } from '../App/Authentication';
 import CssBaseline from '@material-ui/core/CssBaseline';
 import Link from '@material-ui/core/Link';
 import Box from '@material-ui/core/Box';
-import Typography from '@material-ui/core/Typography';
 import { makeStyles } from '@material-ui/core/styles';
 import Container from '@material-ui/core/Container';
 import { Config } from '../../config';
 import Navigation from "../App/Navigation";
+import { Stack } from '@mui/material';
 
 function Copyright() {
   return (
@@ -72,7 +72,9 @@ function UpdateListing(props) {
   const [roomAvailable, setRoomAvailable] = useState(new Date());
   const [rent, setRent] = useState(0);
   const [rentUnits, setRentUnits] = useState('');
-  const [utilities, setUtilities] = useState('');
+  const [utilities, setUtilities] = useState({
+      power: false, water: false, internet: false
+  });
   const [active, setActive] = useState(true);
 
   //Method to check if an error is detected on form submit - rent can't be $0
@@ -136,6 +138,18 @@ function UpdateListing(props) {
     setActive(event.target.checked);
   };
 
+  const changePower = () => {
+    setUtilities({...utilities, power: !utilities.power});
+}
+
+const changeWater = () => {
+    setUtilities({...utilities, water: !utilities.water});
+}
+
+const changeInternet = () => {
+    setUtilities({...utilities, internet: !utilities.internet});
+}
+
   //Load the listing passed by the previous page from the DB
   useEffect(() => {
     async function getListing() {
@@ -159,7 +173,11 @@ function UpdateListing(props) {
       setRoomAvailable(listing.roomAvailable);
       setRent(listing.rent);
       setRentUnits(listing.rentUnits);
-      setUtilities(listing.utilities);
+        if (listing.utilities === undefined) {
+            setUtilities({power: false, water: false, internet: false})
+        } else {
+            setUtilities(listing.utilities)
+        }
     }
   }, [listing])
 
@@ -196,21 +214,6 @@ function UpdateListing(props) {
             </div>
             <br /><br /><br /><br />
             <div>
-              <FormControl>
-                <TextField className="input"
-                  label="Utilities"
-                  multiline
-                  maxRows={2}
-                  minRows={2}
-                  required
-                  variant="outlined"
-                  value={utilities}
-                  onChange={(e) => { setUtilities(e.target.value) }}
-                />
-              </FormControl>
-            </div>
-            <br /><br /><br />
-            <div>
               <InputLabel
                 error={isInvalid.rent}
               > Rent Amount (in $NZ)</InputLabel>
@@ -246,6 +249,31 @@ function UpdateListing(props) {
               </FormControl>
             </div>
             <br /><br />
+            <InputLabel>Utilities Included</InputLabel>
+            <Grid item xs = {12} >
+                    <br/>
+                    <Stack direction = "row" spacing = {2}>
+                        <Chip 
+                        label = "Power" 
+                        variant = {utilities.power == false ? "outlined" : "default"}
+                        onClick ={changePower}
+                        color = {utilities.power == false ? "default" : "primary"}
+                        />
+                        <Chip 
+                        label = "Water" 
+                        variant = {utilities.water == false ? "outlined" : "default"}
+                        onClick ={changeWater}
+                        color = {utilities.water == false ? "default" : "primary"}
+                        />
+                        <Chip 
+                        label = "Internet" 
+                        variant = {utilities.internet == false ? "outlined" : "default"} 
+                        onClick ={changeInternet}
+                        color = {utilities.internet == false ? "default" : "primary"}
+                        />
+                    </Stack>
+                </Grid>
+            <br/>
             <div>
               <InputLabel>Available From:</InputLabel>
               <DatePicker

--- a/src/components/Listing/UpdateListing.js
+++ b/src/components/Listing/UpdateListing.js
@@ -133,11 +133,13 @@ function UpdateListing(props) {
     // }
   }
 
-  //Event handler for the active switch - the owner accoount is able to toggle whether the listing is available or not directly from the listing page, without having to oopen the update listing page
+  //Event handler for the active switch - the owner accoount is able to toggle whether the listing is 
+  //available or not directly from the listing page, without having to oopen the update listing page
   const handleChange = (event) => {
     setActive(event.target.checked);
   };
 
+  //Methods for changing state of the utilities, which triggers a change in the chips too
   const changePower = () => {
     setUtilities({...utilities, power: !utilities.power});
 }
@@ -173,6 +175,7 @@ const changeInternet = () => {
       setRoomAvailable(listing.roomAvailable);
       setRent(listing.rent);
       setRentUnits(listing.rentUnits);
+      //Here just to support legacy listings
         if (listing.utilities === undefined) {
             setUtilities({power: false, water: false, internet: false})
         } else {

--- a/src/components/Match/ShowInfo.js
+++ b/src/components/Match/ShowInfo.js
@@ -101,8 +101,9 @@ const renderFlatee = (classes, Listing) => (
                     </Typography>
                     <br/>
                     <Stack direction = "row" spacing = {2}>
-                        <Chip label = "Power" variant = "outlined"/>
-                        <Chip label = "Water" variant = "outlined"/>
+                        {Listing.listing.utilities.power && <Chip label = "Power" variant = "outlined"/>}
+                        {Listing.listing.utilities.water && <Chip label = "Water" variant = "outlined"/>}
+                        {Listing.listing.utilities.internet && <Chip label = "Internet" variant = "outlined"/>}
                     </Stack>
                 </Grid>
 


### PR DESCRIPTION
Changed the utilities from being a string describing what utilities are included with the rent. Now when creating a listing, the user can select boxes for "power", "water", and "internet", to indicate to the potential flatees that these are included in the rent. On the listing card, the flatee will only see the ones which are included being displayed.